### PR TITLE
Install Python from conda-forge rather than Anaconda

### DIFF
--- a/conda_env.yml
+++ b/conda_env.yml
@@ -1,6 +1,6 @@
 name: agora
 channels:
-    - defaults
+    - conda-forge
 dependencies:
     - python=3.7
     - pip


### PR DESCRIPTION
Bonjour !

Je sais pas si vous avez vu mais [Anaconda fait des misères à des organismes de recherche](https://www.theregister.com/2024/08/08/anaconda_puts_the_squeeze_on/) (y compris le Sanger !). 
`defaults` correspond aux canaux qui sont sous licence (potentiellement payante) d'Anaconda, tandis que `conda-forge` est [libre et maintenu par la communauté](https://conda-forge.org/).
J'ai vérifié que `checkAgoraIntegrity.sh` fonctionne comme prévu.

Bises,
Matthieu